### PR TITLE
Feature: Add `toc.integrate`

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ theme:
   features:
     - content.code.copy
     - navigation.footer
+    - toc.integrate
 
 
 


### PR DESCRIPTION
Before:

![image](https://github.com/vttresearch/quantum-computer-documentation/assets/67475147/fbe68f5a-7325-4d1a-aa60-0a8d1d3bf5ae)


After:

![image](https://github.com/vttresearch/quantum-computer-documentation/assets/67475147/887f1919-aea3-4c9b-8b66-4d9a1c97afa9)


Right hand side TOC is empty.